### PR TITLE
ADD rethrow error to forward catched error response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .DS_Store
 dist
+.idea

--- a/src/react/ssr/use-axios-interceptor-ssr.ts
+++ b/src/react/ssr/use-axios-interceptor-ssr.ts
@@ -27,11 +27,11 @@ export default function useAxiosInterceptorSSR(axios: Axios) {
       },
       (error) => {
         const axiosUIData = error?.response?.data?.axiosUIData;
-
         if (axiosUIData) {
           delete error.response.data.axiosUIData;
           addData(axiosUIData);
         }
+        throw error;
       }
     );
     intercepted.current = true;


### PR DESCRIPTION
With v0.3.0 the handling of error responses was introduced. But the response was not rethrown/forwarded so data in any fetch/useQuery/useMutation was just undefined for non-200/300 responses.